### PR TITLE
requests.get replaced with async

### DIFF
--- a/cogs/mma.py
+++ b/cogs/mma.py
@@ -3,6 +3,7 @@ from urllib.parse import quote_plus
 import logging
 import shlex
 import coloredlogs
+import aiohttp
 
 import discord
 from discord.ext import commands
@@ -49,6 +50,7 @@ fighter_stats_url = (
 
 try:
     countries = requests.get("https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/master/slim-2/slim-2.json").json()
+    
 except:
     countries = []
 
@@ -275,13 +277,21 @@ class MMACog(commands.Cog, name="MMA"):
         Use --schedule/sched                to fetch the next 5 events.
         Use --date YYYYMMDD                 to fetch events on a specific date.
         """
+
+        @staticmethod
+        async def fetch_json(url: str):
+            async with aiohttp.ClientSession() as cs:
+                async with cs.get(url) as r:
+                    return await r.json()
+
         options = self.parseargs(optional_input)
         # print(options)
         # print(trigger.group(1))#, optional_input)
         try:
-            schedule = requests.get(schedule_url + "&league=ufc" if 'ufc' in ctx.invoked_with.lower() else schedule_url)
-            print(schedule.url)
-            schedule = schedule.json()
+            # schedule = requests.get(schedule_url + "&league=ufc" if 'ufc' in ctx.invoked_with.lower() else schedule_url)
+            schedule = await fetch_json(schedule_url + "&league=ufc" if 'ufc' in ctx.invoked_with.lower() else schedule_url)
+            # print(schedule.url)
+            # schedule = schedule.json()
         except:
             await ctx.send("```\nI couldn't fetch the schedule\n```")
             return

--- a/cogs/mma.py
+++ b/cogs/mma.py
@@ -69,6 +69,12 @@ class MMACog(commands.Cog, name="MMA"):
     def __init__(self, bot):
         self.bot = bot
         self.__name__ = __name__
+    
+    @staticmethod
+    async def fetch_json(url: str):
+        async with aiohttp.ClientSession() as cs:
+            async with cs.get(url) as r:
+                return await r.json()
 
     # @commands.command(name="fighter")
     # # @commands.example(".fighter overeem")
@@ -278,18 +284,12 @@ class MMACog(commands.Cog, name="MMA"):
         Use --date YYYYMMDD                 to fetch events on a specific date.
         """
 
-        @staticmethod
-        async def fetch_json(url: str):
-            async with aiohttp.ClientSession() as cs:
-                async with cs.get(url) as r:
-                    return await r.json()
-
         options = self.parseargs(optional_input)
         # print(options)
         # print(trigger.group(1))#, optional_input)
         try:
             # schedule = requests.get(schedule_url + "&league=ufc" if 'ufc' in ctx.invoked_with.lower() else schedule_url)
-            schedule = await fetch_json(schedule_url + "&league=ufc" if 'ufc' in ctx.invoked_with.lower() else schedule_url)
+            schedule = await self.fetch_json(schedule_url + "&league=ufc" if 'ufc' in ctx.invoked_with.lower() else schedule_url)
             # print(schedule.url)
             # schedule = schedule.json()
         except:

--- a/cogs/sports.py
+++ b/cogs/sports.py
@@ -4,6 +4,7 @@ from discord.utils import get
 
 import requests
 import pendulum
+import aiohttp
 
 import logging
 import coloredlogs
@@ -168,6 +169,11 @@ class SportsCog(commands.Cog, name="Sports"):
             "WAS": "Washington",
             "WSH": "Washington",
         }
+    
+    async def fetch_json(self, url: str):
+        async with aiohttp.ClientSession() as cs:
+            async with cs.get(url) as r:
+                return await r.json()
 
     @commands.command(name='sports', pass_context=True)
     @commands.cooldown(1, 5, commands.BucketType.user)
@@ -656,11 +662,6 @@ class SportsCog(commands.Cog, name="Sports"):
              nhl --tz US/Pacific
              nhl --tz pdt bos
         """
-
-        async def fetch_json(self, url: str):
-            async with aiohttp.ClientSession() as cs:
-                async with cs.get(url) as r:
-                    return await r.json()
 
         mobile_output = False
         member = ctx.author

--- a/cogs/sports.py
+++ b/cogs/sports.py
@@ -657,6 +657,11 @@ class SportsCog(commands.Cog, name="Sports"):
              nhl --tz pdt bos
         """
 
+        async def fetch_json(self, url: str):
+            async with aiohttp.ClientSession() as cs:
+                async with cs.get(url) as r:
+                    return await r.json()
+
         mobile_output = False
         member = ctx.author
         member_id = str(member.id)
@@ -716,7 +721,8 @@ class SportsCog(commands.Cog, name="Sports"):
         url = self.NHL_SCOREBOARD_ENDPOINT.format(date, date) + str(append_team)
         LOGGER.debug("NHL API called for: {}".format(url))
 
-        data = requests.get(url).json()
+        # data = requests.get(url).json()
+        data = await self.fetch_json(url)
         games = data.get('dates', {})
         if not games:
             LOGGER.warn("Something went wrong possibly. (NHL)")
@@ -959,7 +965,8 @@ class SportsCog(commands.Cog, name="Sports"):
         url = self.MLB_SCOREBOARD_ENDPOINT.format(date) + str(append_team)
         LOGGER.debug("MLB API called for: {}".format(url))
 
-        data = requests.get(url).json()
+        # data = requests.get(url).json()
+        data = await self.fetch_json(url)
         games = data.get('dates', {})
         if not games:
             LOGGER.warn("Something went wrong possibly. (MLB: fetching games)")
@@ -1356,7 +1363,8 @@ class SportsCog(commands.Cog, name="Sports"):
         url = self.NBA_SCOREBOARD_ENDPOINT.format(date) #+ str(append_team)
         LOGGER.debug("NBA API called for: {}".format(url))
 
-        data = requests.get(url).json()
+        # data = requests.get(url).json()
+        data = await self.fetch_json(url)
         games = data.get('games', {})
         if not games:
             LOGGER.warn("Something went wrong possibly. (NBA: fetching games)")


### PR DESCRIPTION
I replaced requests.get in `mma.py` and `sports.py` with one of its asynchronous alternatives. This was an essential change since requests.get is blocking and discord.py is an asynchronous library